### PR TITLE
Update Dockerfile.build

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -4,6 +4,7 @@ MAINTAINER Kazumichi Yamamoto <yamamoto.febc@gmail.com>
 
 RUN  apt-get update && apt-get -y install bash git make zip && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 RUN go get -u github.com/motemen/gobump/cmd/gobump
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.22.2
 ADD . /go/src/github.com/yamamoto-febc/terraform-provider-rke
 WORKDIR /go/src/github.com/yamamoto-febc/terraform-provider-rke
 CMD ["make"]


### PR DESCRIPTION
Installing golangci-lint into docker build image (otherwise: "/bin/sh: 1: golangci-lint: not found")