### PR TITLE
AWS example fixes

### DIFF
--- a/examples/aws_ec2/aws/nodes.tf
+++ b/examples/aws_ec2/aws/nodes.tf
@@ -53,7 +53,7 @@ resource "aws_instance" "rke-node" {
     }
 
     inline = [
-      "curl https://releases.rancher.com/install-docker/18.09.sh | sh",
+      "curl ${var.docker_install_url} | sh",
       "sudo usermod -a -G docker ubuntu",
     ]
   }

--- a/examples/aws_ec2/aws/nodes.tf
+++ b/examples/aws_ec2/aws/nodes.tf
@@ -53,7 +53,7 @@ resource "aws_instance" "rke-node" {
     }
 
     inline = [
-      "curl releases.rancher.com/install-docker/1.12.sh | bash",
+      "curl https://releases.rancher.com/install-docker/18.09.sh | sh",
       "sudo usermod -a -G docker ubuntu",
     ]
   }

--- a/examples/aws_ec2/aws/outputs.tf
+++ b/examples/aws_ec2/aws/outputs.tf
@@ -10,3 +10,6 @@ output "addresses" {
   value = aws_instance.rke-node[*].public_dns
 }
 
+output "internal_ips" {
+  value = aws_instance.rke-node[*].private_ip
+}

--- a/examples/aws_ec2/aws/variables.tf
+++ b/examples/aws_ec2/aws/variables.tf
@@ -10,3 +10,6 @@ variable "cluster_id" {
   default = "rke"
 }
 
+variable "docker_install_url" {
+  default = "https://releases.rancher.com/install-docker/18.09.sh"
+}

--- a/examples/aws_ec2/rke.tf
+++ b/examples/aws_ec2/rke.tf
@@ -12,24 +12,28 @@ resource "rke_cluster" "cluster" {
 
   nodes {
     address = module.nodes.addresses[0]
+    internal_address = module.nodes.internal_ips[0]
     user    = module.nodes.ssh_username
     ssh_key = module.nodes.private_key
     role    = ["controlplane", "etcd"]
   }
   nodes {
     address = module.nodes.addresses[1]
+    internal_address = module.nodes.internal_ips[1]
     user    = module.nodes.ssh_username
     ssh_key = module.nodes.private_key
     role    = ["worker"]
   }
   nodes {
     address = module.nodes.addresses[2]
+    internal_address = module.nodes.internal_ips[2]
     user    = module.nodes.ssh_username
     ssh_key = module.nodes.private_key
     role    = ["worker"]
   }
   nodes {
     address = module.nodes.addresses[3]
+    internal_address = module.nodes.internal_ips[3]
     user    = module.nodes.ssh_username
     ssh_key = module.nodes.private_key
     role    = ["worker"]


### PR DESCRIPTION
When trying the AWS [example](https://github.com/rancher/terraform-provider-rke/tree/master/examples/aws_ec2) I encountered a few issues. 
Below are the fixes required to successfully bring up a cluster using the example resources:

0b96df5 - [Current](https://github.com/rancher/terraform-provider-rke/blob/bc87a2a790e7aaf7313be00aeddd5c1dfdef2d4f/examples/aws_ec2/aws/nodes.tf#L56) Docker (`releases.rancher.com/install-docker/1.12.sh`) install fails with:

```
module.nodes.aws_instance.rke-node[0] (remote-exec): + sudo -E sh -c 'sleep 3; apt-get install -y -q dirmngr'
module.nodes.aws_instance.rke-node[0] (remote-exec): Reading package lists...

module.nodes.aws_instance.rke-node[0] (remote-exec): Building dependency tree...
module.nodes.aws_instance.rke-node[0] (remote-exec): Reading state information...
module.nodes.aws_instance.rke-node[0] (remote-exec): Some packages could not be installed. This may mean that you have
module.nodes.aws_instance.rke-node[0] (remote-exec): requested an impossible situation or if you are using the unstable
module.nodes.aws_instance.rke-node[0] (remote-exec): distribution that some required packages have not yet been created
module.nodes.aws_instance.rke-node[0] (remote-exec): or been moved out of Incoming.
module.nodes.aws_instance.rke-node[0] (remote-exec): The following information may help to resolve the situation:

module.nodes.aws_instance.rke-node[0] (remote-exec): The following packages have unmet dependencies:
module.nodes.aws_instance.rke-node[0] (remote-exec):  dirmngr : Depends: libassuan0 (>= 2.4.0) but it is not installable
module.nodes.aws_instance.rke-node[0] (remote-exec):            Depends: libnpth0 (>= 0.90) but it is not installable
module.nodes.aws_instance.rke-node[0] (remote-exec): E: Unable to correct problems, you have held broken packages.
module.nodes.aws_instance.rke-node[0] (remote-exec): usermod: group 'docker' does not exist


Error: error executing "/tmp/terraform_2106265970.sh": Process exited with status 6
```

bumping to `https://releases.rancher.com/install-docker/18.09.sh` (as per https://rancher.com/docs/rancher/v2.x/en/installation/requirements/installing-docker/).

e003b67 - Due to https://github.com/rancher/rke/issues/1725 we need to include the node `internal_address`. Additionally, this has to be the _IP_ and not internal DNS, due to https://github.com/etcd-io/etcd/issues/9575

d9d69f4 - Upgrade to `rke v1.0.2` to prevent `kube-apiserver` not starting due to https://github.com/rancher/rke/issues/1805