### PR TITLE
add link to terraform-openstack-rke module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ Provider examples
 
 You can view some tf file examples, [here](examples).
 
+On Openstack you can use [terraform-openstack-rke](https://github.com/remche/terraform-openstack-rke) module.


### PR DESCRIPTION
This PR adds a link in examples section to the terraform-openstack-rke module.