### PR TITLE
Fix nodes.port argument definition on rke_cluster resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-
+* Fix `nodes.port` argument definition on `rke_cluster` resource
 
 ## 1.0.0-rc1 (January 21, 2020)
 

--- a/rke/schema_rke_cluster_node.go
+++ b/rke/schema_rke_cluster_node.go
@@ -67,11 +67,10 @@ func rkeClusterNodeFields() map[string]*schema.Schema {
 			Description: "Name of the host provisioned via docker machine",
 		},
 		"port": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Default:      "22",
-			ValidateFunc: validation.IntBetween(1, 65535),
-			Description:  "Port used for SSH communication",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "22",
+			Description: "Port used for SSH communication",
 		},
 		"ssh_agent_auth": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
Fix issue #155 