### PR TITLE
Save rke_cluster resource data in tfstate even if clusterUp fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 ENHANCEMENTS:
 
 * Updated go modules and vendor files to support RKE v1.0.2
+* Save `rke_cluster` resource data in tfstate even if `clusterUp` fails, to be able to retry
 
 BUG FIXES:
 

--- a/rke/resource_rke_cluster.go
+++ b/rke/resource_rke_cluster.go
@@ -111,12 +111,13 @@ func clusterUp(d *schema.ResourceData) error {
 	}
 
 	apiURL, caCrt, clientCert, clientKey, _, clusterUpErr := cmd.ClusterUp(context.Background(), hosts.DialersOptions{}, flags, map[string]interface{}{})
+	// set keys to resourceData
+	err = setRKEClusterKeys(d, apiURL, caCrt, clientCert, clientKey, tempDir, rkeConfig)
 	if clusterUpErr != nil {
 		return clusterUpErr
 	}
 
-	// set keys to resourceData
-	return setRKEClusterKeys(d, apiURL, caCrt, clientCert, clientKey, tempDir, rkeConfig)
+	return err
 }
 
 func clusterRemove(d *schema.ResourceData) error {


### PR DESCRIPTION
Fix issue #152 