### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Building The Provider
 Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-rancher2`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/rancher; cd $GOPATH/src/github.com/rancher
-$ git clone git@github.com:rancher/terraform-provider-rancher2
+$ mkdir -p $GOPATH/src/github.com/rancher
+$ cd $GOPATH/src/github.com/rancher
+
+$ go get github.com/rancher/terraform-provider-rke
+$ go install github.com/rancher/terraform-provider-rke
 ```
 
 Enter the provider directory and build the provider

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-rancher2`
+Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-rke`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/rancher


### PR DESCRIPTION
- Found typo on git clone: `git clone git@github.com:rancher/terraform-provider-rancher2`
- Replaced build workflow with simple `got get` and `go install`
  - Avoids downloading make(alpine terraform:full) and adding github authorize host (thinking container)
  - Simpler when no need to develop the provider