### PR TITLE
Ordering rancher2_cluster.certificates to avoid output diff on tf 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.1.2 (Unreleased)
+
+FEATURES:
+
+
+
+ENHANCEMENTS:
+
+
+
+BUG FIXES:
+
+* Ordering `rancher2_cluster.certificates` to avoid output diff on tf 0.13
+
 ## 1.1.1 (August 28, 2020)
 
 FEATURES:

--- a/rke/structure_rke_cluster_certificates.go
+++ b/rke/structure_rke_cluster_certificates.go
@@ -1,6 +1,8 @@
 package rke
 
 import (
+	"sort"
+
 	"github.com/rancher/rke/pki"
 )
 
@@ -11,19 +13,19 @@ const (
 // Flatteners
 
 func flattenRKEClusterCertificates(in map[string]pki.CertificatePKI) (string, string, string, []interface{}) {
-	out := []interface{}{}
-
 	var caCrt, clientCrt, clientKey string
-
-	for k, v := range in {
-		/*certPEM := ""
-		if v.Certificate != nil {
-			certPEM = certificateToPEM(v.Certificate)
-		}
-		privateKeyPEM := ""
-		if v.Key != nil {
-			privateKeyPEM = privateKeyToPEM(v.Key)
-		}*/
+	outLen := len(in)
+	if in == nil || outLen == 0 {
+		return caCrt, clientCrt, clientKey, []interface{}{}
+	}
+	sortedKeys := make([]string, 0, outLen)
+	for k := range in {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	out := make([]interface{}, outLen)
+	for i, k := range sortedKeys {
+		v := in[k]
 
 		if k == pki.CACertName {
 			caCrt = v.CertificatePEM
@@ -49,9 +51,7 @@ func flattenRKEClusterCertificates(in map[string]pki.CertificatePKI) (string, st
 			"config_env_name": v.ConfigEnvName,
 			"config_path":     v.ConfigPath,
 		}
-
-		out = append(out, obj)
+		out[i] = obj
 	}
-
 	return caCrt, clientCrt, clientKey, out
 }


### PR DESCRIPTION
Closes #245 