### PR TITLE
Required Provider for RKE

### DIFF
--- a/examples/aws_ec2/aws/main.tf
+++ b/examples/aws_ec2/aws/main.tf
@@ -1,4 +1,12 @@
 provider "aws" {
   region = var.region
 }
+terraform {
+  required_providers {
+    rke = {
+      source = "rancher/rke"
+      version = "1.1.2"
+    }
+  }
+}
 

--- a/examples/aws_ec2/aws/main.tf
+++ b/examples/aws_ec2/aws/main.tf
@@ -1,12 +1,4 @@
 provider "aws" {
   region = var.region
 }
-terraform {
-  required_providers {
-    rke = {
-      source = "rancher/rke"
-      version = "1.1.2"
-    }
-  }
-}
 

--- a/examples/aws_ec2/rke.tf
+++ b/examples/aws_ec2/rke.tf
@@ -5,6 +5,15 @@ module "nodes" {
   # cluster_id    = "rke"
 }
 
+terraform {
+  required_providers {
+    rke = {
+      source = "rancher/rke"
+      version = "1.1.2"
+    }
+  }
+}
+
 resource "rke_cluster" "cluster" {
   cloud_provider {
     name = "aws"


### PR DESCRIPTION
Adding this terraform required providers allows `terraform init` to be run without additional installation steps. 