### PR TITLE
Fixed for #186

### DIFF
--- a/examples/aws_ec2/aws/ami.tf
+++ b/examples/aws_ec2/aws/ami.tf
@@ -3,8 +3,8 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
-  }
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+}
 
   filter {
     name   = "virtualization-type"

--- a/examples/aws_ec2/aws/ami.tf
+++ b/examples/aws_ec2/aws/ami.tf
@@ -4,7 +4,7 @@ data "aws_ami" "ubuntu" {
   filter {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
-}
+  }
 
   filter {
     name   = "virtualization-type"

--- a/examples/aws_ec2/aws/variables.tf
+++ b/examples/aws_ec2/aws/variables.tf
@@ -3,7 +3,7 @@ variable "region" {
 }
 
 variable "instance_type" {
-  default = "t2.micro"
+  default = "t3.large"
 }
 
 variable "cluster_id" {
@@ -11,5 +11,5 @@ variable "cluster_id" {
 }
 
 variable "docker_install_url" {
-  default = "https://releases.rancher.com/install-docker/18.09.sh"
+  default = "https://releases.rancher.com/install-docker/19.03.sh"
 }

--- a/examples/aws_ec2/aws/variables.tf
+++ b/examples/aws_ec2/aws/variables.tf
@@ -3,7 +3,7 @@ variable "region" {
 }
 
 variable "instance_type" {
-  default = "t3.large"
+  default = "t2.large"
 }
 
 variable "cluster_id" {

--- a/examples/aws_ec2/rke.tf
+++ b/examples/aws_ec2/rke.tf
@@ -1,7 +1,7 @@
 module "nodes" {
   source = "./aws"
   # region        = "us-east-1"
-  # instance_type = "t2.micro"
+  # instance_type = "t2.large"
   # cluster_id    = "rke"
 }
 


### PR DESCRIPTION
Fix for AWS EC2 example since it's somewhat outdated.

Issue #186

Reasons:
- More recent Ubuntu version (from 16 to 18)
- More recent rancher install script version
- Increase default instance size. When trying the example, the cluster would stop responding since the EC2 instances were too small. (From t2.micro to t2.large)