### PR TITLE
Rename the temporary rke config directory

### DIFF
--- a/rke/resource_rke_cluster.go
+++ b/rke/resource_rke_cluster.go
@@ -436,7 +436,7 @@ func createTempDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tempDir, err := ioutil.TempDir(workDir, "terraform-provider-rke-tmp-")
+	tempDir, err := ioutil.TempDir(workDir, "rke-provider-tmp-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As we scaffold the pulumi provider from the go module code here, the user gets a `terraform-provider-rke-tmp-` we are trying to make this a bit more generic 