### PR TITLE
Patch & re-assign `rke_cluster_yaml` post create

### DIFF
--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -226,6 +226,12 @@ func flattenRKECluster(d *schema.ResourceData, in *cluster.Cluster) error {
 		return err
 	}
 
+	rkeClusterYaml, _, err := expandRKECluster(d)
+	err = d.Set("rke_cluster_yaml", rkeClusterYaml)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Issue ref: #326

I found out that the `rke_cluster_yaml` was not updated when calling read after create while the RKE state was... So the read from the first run returns the value from before the execution but later reads from the actual RKE state.