### PR TITLE
Update RKE dependency to 1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.3.1 (Mar 17, 2022)
+
+FEATURES:
+
+
+ENHANCEMENTS:
+
+* Updated RKE to v1.3.7
+
+BUG FIXES:
+
+
+
 ## 1.3.0 (Dec 20, 2021)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
-## 1.3.1 (Mar 17, 2022)
-
-FEATURES:
-
-
-ENHANCEMENTS:
-
-* Updated RKE to v1.3.7
-
-BUG FIXES:
-
-
-
 ## 1.3.0 (Dec 20, 2021)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
-	github.com/rancher/rke v1.3.3
+	github.com/rancher/rke v1.3.7
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect

--- a/go.sum
+++ b/go.sum
@@ -656,8 +656,8 @@ github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91 h1:p4VVl0tr6YAeUILFM
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640 h1:wZT4IWBeMfKewJ+ZSCuOFjHh+voTJWYQo7jTd/ZtE90=
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
-github.com/rancher/rke v1.3.3 h1:XZ3zQ1hhra4bO6a3Wep7hO+fUcDs7TBi1/FdBDEDqB4=
-github.com/rancher/rke v1.3.3/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
+github.com/rancher/rke v1.3.7 h1:2WBQ7GXS6UQ56bgPBiE7A1b74QOXy/HEkxHD8eOYL+4=
+github.com/rancher/rke v1.3.7/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f h1:QPOlhiY3YCPLsEtOmPam+ghtqip/f/zsfz4F4PF70D8=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
According to the changelogs of RKE, there are no changes other than the Rancher hyperkube images. I've tested this, and it works fine.