### PR TITLE
Add enable_cri_dockerd parameter

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -95,6 +95,7 @@ The following arguments are supported:
 * `dind_storage_driver` - (Optional/Experimental) DinD RKE cluster storage driver (string)
 * `dind_dns_server` - (Optional/Experimental) DinD RKE cluster dns (string)
 * `dns` - (Optional) RKE k8s cluster DNS Config (list maxitems:1)
+* `enable_cri_dockerd` - (Optional) Enable/Disable CRI dockerd for kubelet. Default `false` (bool)
 * `ignore_docker_version` - (Optional) Enable/Disable RKE k8s cluster strict docker version checking. Default `false` (bool)
 * `ingress` - (Optional) RKE k8s cluster ingress controller configuration (list maxitems:1)
 * `kubernetes_version` - (Optional) K8s version to deploy. If kubernetes image is specified, image version takes precedence. Default: `rke default` (string)

--- a/rke/resource_rke_cluster_test.go
+++ b/rke/resource_rke_cluster_test.go
@@ -226,6 +226,7 @@ func testAccCheckRKEClusterDestroy(s *terraform.State) error {
 func testAccCheckRKEConfigBasic() string {
 	return fmt.Sprintf(`	
 resource rke_cluster "cluster" {
+  enable_cri_dockerd = true
   ignore_docker_version = true
   addon_job_timeout = 60
   dind = true
@@ -247,6 +248,7 @@ resource rke_cluster "cluster" {
 func testAccCheckRKEConfigUpdate() string {
 	return fmt.Sprintf(`	
 resource rke_cluster "cluster" {
+  enable_cri_dockerd = true
   ignore_docker_version = true
   addon_job_timeout = 60
   dind = true
@@ -300,6 +302,7 @@ resource rke_cluster "cluster" {
 func testAccCheckRKEConfigBasic2Nodes() string {
 	return fmt.Sprintf(`	
 resource rke_cluster "cluster" {
+  enable_cri_dockerd = true
   ignore_docker_version = true
   addon_job_timeout = 60
   dind = true

--- a/rke/schema_rke_cluster.go
+++ b/rke/schema_rke_cluster.go
@@ -143,6 +143,12 @@ func rkeClusterFields() map[string]*schema.Schema {
 				Schema: rkeClusterDNSFields(),
 			},
 		},
+		"enable_cri_dockerd": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Enable/Disable CRI dockerd for kubelet",
+		},
 		"ignore_docker_version": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -89,7 +89,7 @@ func flattenRKECluster(d *schema.ResourceData, in *cluster.Cluster) error {
 	d.Set("dind", in.DinD)
 
 	if _, ok := d.Get("enable_cri_dockerd").(bool); ok && in.EnableCRIDockerd != nil {
-		d.Set("enable_cri_dockerd", in.EnableCRIDockerd)
+		d.Set("enable_cri_dockerd", *in.EnableCRIDockerd)
 	}
 
 	if _, ok := d.Get("ignore_docker_version").(bool); ok && in.IgnoreDockerVersion != nil {

--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -88,6 +88,10 @@ func flattenRKECluster(d *schema.ResourceData, in *cluster.Cluster) error {
 
 	d.Set("dind", in.DinD)
 
+	if _, ok := d.Get("enable_cri_dockerd").(bool); ok && in.EnableCRIDockerd != nil {
+		d.Set("enable_cri_dockerd", in.EnableCRIDockerd)
+	}
+
 	if _, ok := d.Get("ignore_docker_version").(bool); ok && in.IgnoreDockerVersion != nil {
 		d.Set("ignore_docker_version", *in.IgnoreDockerVersion)
 	}
@@ -280,6 +284,10 @@ func expandRKECluster(in *schema.ResourceData) (string, *rancher.RancherKubernet
 
 	if v, ok := in.Get("dns").([]interface{}); ok && len(v) > 0 {
 		obj.DNS = expandRKEClusterDNS(v)
+	}
+
+	if v, ok := in.Get("enable_cri_dockerd").(bool); ok {
+		obj.EnableCRIDockerd = &v
 	}
 
 	if v, ok := in.Get("ignore_docker_version").(bool); ok {


### PR DESCRIPTION
Hi,

Refered to issue [https://github.com/rancher/terraform-provider-rke/issues/325](https://github.com/rancher/terraform-provider-rke/issues/325)

Here is some outputs from my dev env

env var is well defined to the kubelet container, on dev node:
```
docker exec kubelet env                                                                                                                                                                                                                                                          

PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=rke01
RKE_KUBELET_CRIDOCKERD=true
HOME=/root
```

kubelet args are also well defined
```
--container-runtime-endpoint=/var/run/dockershim.sock --container-runtime=remote
```

test is already ensured by rke if we tried an older version than kubernetes 1.21 :
```
rke_cluster.lab: Refreshing state... [id=f8cc1f51-5939-47b9-acc3-7baa527640c2]
local_file.kubeconfig_yaml: Refreshing state... [id=0b42f3ae3e24322d5cc8d646272f57196e001621]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # rke_cluster.lab will be updated in-place
  ~ resource "rke_cluster" "lab" {
      ~ enable_cri_dockerd        = false -> true
        id                        = "f8cc1f51-5939-47b9-acc3-7baa527640c2"
        # (25 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

rke_cluster.lab: Modifying... [id=f8cc1f51-5939-47b9-acc3-7baa527640c2]
╷
│ Error:
│ ============= RKE outputs ==============
│ time="2022-03-30T23:58:53+02:00" level=info msg="Updating RKE cluster..."
│ time="2022-03-30T23:58:53+02:00" level=info msg="Initiating Kubernetes cluster"
│
│ Failed initializing cluster err:Failed to validate cluster: Enabling cri-dockerd for cluster version [v1.20.13-rancher1-1] is not supported
│ ========================================
│
│
│   with rke_cluster.lab,
│   on lab.tf line 1, in resource "rke_cluster" "lab":
│    1: resource "rke_cluster" "lab" {
│
╵
```