### PR TITLE
Add missing call to expand RKE config values

### DIFF
--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -226,6 +226,12 @@ func flattenRKECluster(d *schema.ResourceData, in *cluster.Cluster) error {
 		return err
 	}
 
+	rkeClusterYaml, _, err := expandRKECluster(d)
+	err = d.Set("rke_cluster_yaml", rkeClusterYaml)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rke/issues/326 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

Open source community saw some RKE config values not being computed when deploying an RKE cluster via the terraform provider. This is done by specifying `rke_cluster_yaml` in the tf config. Did not see the same issue when adding services image and extra_env variables to the RKE config, but nested values were not being expanded in general because a call to `expandRKECluster` was missing in the provider.
 
## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add missing code
 
## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

* Create EC2 nodes and provision for RKE installation
* Create a tf config
* Create an RKE config with services image and extra_env variables defined (I added HTTP_PROXY and NO_PROXY to test)
* Run `terraform init`
* Run `terraform apply`
* Run `terraform plan`