### PR TITLE
[DNM] Add `win_extra_args`, `extra_args_array`, and `win_extra_args_array`

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -562,6 +562,9 @@ The following attributes are exported:
 * `creation` - (Optional/Computed) Creation option for etcd service (string)
 * `external_urls` - (Optional/Computed) External urls for etcd service (list)
 * `extra_args` - (Optional/Computed) Extra arguments for etcd service (map)
+* `win_extra_args` - (Optional) Extra arguments for the etcd service on Windows systems (map)
+* `extra_args_array` - (Optional) Extra arguments for the etcd service that can be specified multiple times (set maxitems:1)
+* `win_extra_args_array` - (Optional) Extra arguments for the etcd service that can be specified multiple times on Windows systems (set maxitems:1)
 * `extra_binds` - (Optional/Computed) Extra binds for etcd service (list)
 * `extra_env` - (Optional/Computed) Extra environment for etcd service (list)
 * `gid` - (Optional) Etcd service GID. Default: `0`. For Rancher v2.3.x or above (int)
@@ -571,6 +574,12 @@ The following attributes are exported:
 * `retention` - (Optional/Computed) Retention option for etcd service (string)
 * `snapshot` - (Optional) Snapshot option for etcd service. Default `true` (bool)
 * `uid` - (Optional) Etcd service UID. Default: `0`. For Rancher v2.3.x or above (int)
+
+
+##### `extra_args_array`
+###### Arguments
++ `argument` (Required) the argument to be passed to the service
++ `values` (Required) A list of values to be passed with the argument (list)
 
 ##### `backup_config`
 
@@ -603,6 +612,9 @@ The following attributes are exported:
 * `audit_log` - (Optional/Computed) K8s audit log configuration. (list maxitem: 1)
 * `event_rate_limit` - (Optional) K8s event rate limit configuration. (list maxitem: 1)
 * `extra_args` - (Optional/Computed) Extra arguments for kube API service (map)
+* `win_extra_args` - (Optional) Extra arguments for the kube API service on Windows systems (map)
+* `extra_args_array` - (Optional) Extra arguments for the kube API service that can be specified multiple times (set maxitems:1)
+* `win_extra_args_array` - (Optional) Extra arguments for the kube API service that can be specified multiple times on Windows systems (set maxitems:1)
 * `extra_binds` - (Optional/Computed) Extra binds for kube API service (list)
 * `extra_env` - (Optional/Computed) Extra environment for kube API service (list)
 * `image` - (Optional/Computed) Docker image for kube API service (string)
@@ -610,6 +622,12 @@ The following attributes are exported:
 * `secrets_encryption_config` - (Optional) [Encrypt k8s secret data configration](https://rancher.com/docs/rke/latest/en/config-options/secrets-encryption/). (list maxitem: 1)
 * `service_cluster_ip_range` - (Optional/Computed) Service Cluster IP Range option for kube API service (string)
 * `service_node_port_range` - (Optional/Computed) Service Node Port Range option for kube API service (string)
+
+
+##### `extra_args_array`
+###### Arguments
++ `argument` (Required) the argument to be passed to the service
++ `values` (Required) A list of values to be passed with the argument (list)
 
 ##### `audit_log`
 
@@ -649,10 +667,19 @@ The following attributes are exported:
 
 * `cluster_cidr` - (Optional/Computed) Cluster CIDR option for kube controller service (string)
 * `extra_args` - (Optional/Computed) Extra arguments for kube controller service (map)
+* `win_extra_args` - (Optional) Extra arguments for the kube controller service on Windows systems (map)
+* `extra_args_array` - (Optional) Extra arguments for the kube controller service that can be specified multiple times (set maxitems:1)
+* `win_extra_args_array` - (Optional) Extra arguments for the kube controller service that can be specified multiple times on Windows systems (set maxitems:1)
 * `extra_binds` - (Optional/Computed) Extra binds for kube controller service (list)
 * `extra_env` - (Optional/Computed) Extra environment for kube controller service (list)
 * `image` - (Optional/Computed) Docker image for kube controller service (string)
 * `service_cluster_ip_range` - (Optional/Computed) Service Cluster ip Range option for kube controller service (string)
+
+
+##### `extra_args_array`
+###### Arguments
++ `argument` (Required) the argument to be passed to the service
++ `values` (Required) A list of values to be passed with the argument (list)
 
 #### `kubelet`
 
@@ -661,6 +688,9 @@ The following attributes are exported:
 * `cluster_dns_server` - (Optional/Computed) Cluster DNS Server option for kubelet service (string)
 * `cluster_domain` - (Optional) Cluster Domain option for kubelet service. Default `cluster.local` (string)
 * `extra_args` - (Optional/Computed) Extra arguments for kubelet service (map)
+* `win_extra_args` - (Optional) Extra arguments for the kubelet service on Windows systems (map)
+* `extra_args_array` - (Optional) Extra arguments for the kubelet service that can be specified multiple times (set maxitems:1)
+* `win_extra_args_array` - (Optional) Extra arguments for the kubelet service that can be specified multiple times on Windows systems (set maxitems:1)
 * `extra_binds` - (Optional/Computed) Extra binds for kubelet service (list)
 * `extra_env` - (Optional/Computed) Extra environment for kubelet service (list)
 * `fail_swap_on` - (Optional/Computed) Enable or disable failing when swap on is not supported (bool)
@@ -668,23 +698,48 @@ The following attributes are exported:
 * `image` - (Optional/Computed) Docker image for kubelet service (string)
 * `infra_container_image` - (Optional/Computed) Infra container image for kubelet service (string)
 
+
+##### `extra_args_array`
+###### Arguments
++ `argument` (Required) the argument to be passed to the service
++ `values` (Required) A list of values to be passed with the argument (list)
+
 #### `kubeproxy`
 
 ##### Arguments
 
 * `extra_args` - (Optional/Computed) Extra arguments for kubeproxy service (map)
+* `win_extra_args` - (Optional) Extra arguments for the kubeproxy service on Windows systems (map)
+* `extra_args_array` - (Optional) Extra arguments for the kubeproxy service that can be specified multiple times (set maxitems:1)
+* `win_extra_args_array` - (Optional) Extra arguments for the kubeproxy service that can be specified multiple times on Windows systems (set maxitems:1)
 * `extra_binds` - (Optional/Computed) Extra binds for kubeproxy service (list)
 * `extra_env` - (Optional/Computed) Extra environment for kubeproxy service (list)
 * `image` - (Optional/Computed) Docker image for kubeproxy service (string)
+
+
+##### `extra_args_array`
+###### Arguments
++ `argument` (Required) the argument to be passed to the service
++ `values` (Required) A list of values to be passed with the argument (list)
+
 
 #### `scheduler`
 
 ##### Arguments
 
 * `extra_args` - (Optional/Computed) Extra arguments for scheduler service (map)
+* `win_extra_args` - (Optional) Extra arguments for the scheduler service on Windows systems (map)
+* `extra_args_array` - (Optional) Extra arguments for the scheduler service that can be specified multiple times (set maxitems:1)
+* `win_extra_args_array` - (Optional) Extra arguments for the scheduler service that can be specified multiple times on Windows systems (set maxitems:1)
 * `extra_binds` - (Optional/Computed) Extra binds for scheduler service (list)
 * `extra_env` - (Optional/Computed) Extra environment for scheduler service (list)
 * `image` - (Optional/Computed) Docker image for scheduler service (string)
+
+
+##### `extra_args_array`
+###### Arguments
++ `argument` (Required) the argument to be passed to the service
++ `values` (Required) A list of values to be passed with the argument (list)
 
 ### `system_images`
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/rancher/rke v1.3.11
+	github.com/rancher/rke v1.3.12
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/sirupsen/logrus v1.8.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -122,7 +122,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/opencontainers/runc v1.1.1 // indirect
+	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -177,7 +177,7 @@ require (
 	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0 // indirect
 	k8s.io/cli-runtime v0.23.3 // indirect
 	k8s.io/component-base v0.23.6 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -733,8 +733,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
-github.com/opencontainers/runc v1.1.1 h1:PJ9DSs2sVwE0iVr++pAHE6QkS9tzcVWozlPifdwMgrU=
-github.com/opencontainers/runc v1.1.1/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
+github.com/opencontainers/runc v1.1.2 h1:2VSZwLx5k/BfsBxMMipG/LYUnmqOD/BPkIVgQUcTlLw=
+github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
@@ -794,8 +794,8 @@ github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0 h1:ng7i8n0kzTGnXyvVK
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb h1:Tr5rialcd0u13TPRFekmCzwZNalLs5lbg6JSliUD0gY=
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb/go.mod h1:gDEwYUxOknJaOG1jjcH40PQ8U8xnvB+sHph5VirKINY=
-github.com/rancher/rke v1.3.11 h1:GqH7SeSBlFdjaTp4OaFZDkYkfPJjMwuT2QDw5FgP9ps=
-github.com/rancher/rke v1.3.11/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
+github.com/rancher/rke v1.3.12 h1:Dq8RjDjXYP7HVDJwRxqzt1MMZW6My+7QXdJE3q4rhWM=
+github.com/rancher/rke v1.3.12/go.mod h1:LwUwfCzbt74yf6Jc8qTJ99H5iOTHNbhTee7QcWktc0w=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106 h1:ed0NTDvIwulez4zVvBZ1U7mFe2PBxtHvJ9bn2l9bcZ8=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
@@ -1477,8 +1477,9 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/rke/schema_rke_cluster_services_etcd.go
+++ b/rke/schema_rke_cluster_services_etcd.go
@@ -81,6 +81,30 @@ func rkeClusterServicesEtcdBackupConfigFields() map[string]*schema.Schema {
 	return s
 }
 
+func rkeClusterServicesEtcdExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extra_arg": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"argument": {
+						Required: true,
+						Type:     schema.TypeString,
+					},
+					"values": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func rkeClusterServicesEtcdFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"backup_config": {
@@ -118,9 +142,34 @@ func rkeClusterServicesEtcdFields() map[string]*schema.Schema {
 			},
 		},
 		"extra_args": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments that are added to the etcd services",
+		},
+		"win_extra_args": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments for Windows systems that are added to the scheduler services",
+		},
+		"extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments that can be specified multiple times which are added to the etcd services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesEtcdExtraArgsArrayFields(),
+			},
+		},
+		"win_extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments for Windows systems that can be specified multiple times which are added to the etcd services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesEtcdExtraArgsArrayFields(),
+			},
 		},
 		"extra_binds": {
 			Type:     schema.TypeList,

--- a/rke/schema_rke_cluster_services_kube_api.go
+++ b/rke/schema_rke_cluster_services_kube_api.go
@@ -174,6 +174,30 @@ func rkeClusterServicesKubeAPIEventRateLimitFields() map[string]*schema.Schema {
 	return s
 }
 
+func rkeClusterServicesKubeAPIExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extra_arg": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"argument": {
+						Required: true,
+						Type:     schema.TypeString,
+					},
+					"values": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func rkeClusterServicesKubeAPISecretsEncryptionConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"custom_config": {
@@ -258,6 +282,30 @@ func rkeClusterServicesKubeAPIFields() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Description: "Extra arguments that are added to the kube-api services",
+		},
+		"win_extra_args": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments for Windows systems that are added to the scheduler services",
+		},
+		"extra_args_array": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra Arguments that can be specified multiple times which are added to kube-api services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeAPIExtraArgsArrayFields(),
+			},
+		},
+		"win_extra_args_array": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra Arguments for Windows systems that can be specified multiple times which are added to kube-api services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeAPIExtraArgsArrayFields(),
+			},
 		},
 		"extra_binds": {
 			Type:        schema.TypeList,

--- a/rke/schema_rke_cluster_services_kube_controller.go
+++ b/rke/schema_rke_cluster_services_kube_controller.go
@@ -20,6 +20,30 @@ func rkeClusterServicesKubeControllerFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Extra arguments that are added to the kube-controller service",
 		},
+		"win_extra_args": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments for Windows systems that are added to the scheduler services",
+		},
+		"extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments that can be specified multiple times which are added to the kube-controller service",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeControllerExtraArgsArrayFields(),
+			},
+		},
+		"win_extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments for Windows systems that can be specified multiple times which are added to the kube-controller service",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeControllerExtraArgsArrayFields(),
+			},
+		},
 		"extra_binds": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -52,4 +76,28 @@ func rkeClusterServicesKubeControllerFields() map[string]*schema.Schema {
 		},
 	}
 	return s
+}
+
+func rkeClusterServicesKubeControllerExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extra_arg": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"argument": {
+						Required: true,
+						Type:     schema.TypeString,
+					},
+					"values": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/rke/schema_rke_cluster_services_kubelet.go
+++ b/rke/schema_rke_cluster_services_kubelet.go
@@ -26,6 +26,30 @@ func rkeClusterServicesKubeletFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Extra arguments that are added to the kubelet services",
 		},
+		"win_extra_args": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments for Windows systems that are added to the scheduler services",
+		},
+		"extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments that can be added multiple times which are added to the kubelet services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeletExtraArgsArrayFields(),
+			},
+		},
+		"win_extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments for Windows systems that can be added multiple times which are added to the kubelet services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeletExtraArgsArrayFields(),
+			},
+		},
 		"extra_binds": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -69,4 +93,28 @@ func rkeClusterServicesKubeletFields() map[string]*schema.Schema {
 		},
 	}
 	return s
+}
+
+func rkeClusterServicesKubeletExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extra_arg": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"argument": {
+						Required: true,
+						Type:     schema.TypeString,
+					},
+					"values": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/rke/schema_rke_cluster_services_kubeproxy.go
+++ b/rke/schema_rke_cluster_services_kubeproxy.go
@@ -14,6 +14,30 @@ func rkeClusterServicesKubeproxyFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Extra arguments that are added to the kubeproxy services",
 		},
+		"win_extra_args": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments for Windows systems that are added to the scheduler services",
+		},
+		"extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments that can be specified multiple times which are added to the kubeproxy services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeProxyExtraArgsArrayFields(),
+			},
+		},
+		"win_extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments for Windows systems that can be specified multiple times which are added to the kubeproxy services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesKubeProxyExtraArgsArrayFields(),
+			},
+		},
 		"extra_binds": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -40,4 +64,28 @@ func rkeClusterServicesKubeproxyFields() map[string]*schema.Schema {
 		},
 	}
 	return s
+}
+
+func rkeClusterServicesKubeProxyExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extra_arg": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"argument": {
+						Required: true,
+						Type:     schema.TypeString,
+					},
+					"values": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/rke/schema_rke_cluster_services_scheduler.go
+++ b/rke/schema_rke_cluster_services_scheduler.go
@@ -14,6 +14,30 @@ func rkeClusterServicesSchedulerFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Extra arguments that are added to the scheduler services",
 		},
+		"win_extra_args": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Extra arguments for Windows systems that are added to the scheduler services",
+		},
+		"extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments that can be specified multiple times which are added to the scheduler services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesSchedulerExtraArgsArrayFields(),
+			},
+		},
+		"win_extra_args_array": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Extra arguments for Windows systems that can be specified multiple times which are added to the scheduler services",
+			Elem: &schema.Resource{
+				Schema: rkeClusterServicesSchedulerExtraArgsArrayFields(),
+			},
+		},
 		"extra_binds": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -40,4 +64,28 @@ func rkeClusterServicesSchedulerFields() map[string]*schema.Schema {
 		},
 	}
 	return s
+}
+
+func rkeClusterServicesSchedulerExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extra_arg": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"argument": {
+						Required: true,
+						Type:     schema.TypeString,
+					},
+					"values": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/rke/structure_rke_cluster_services.go
+++ b/rke/structure_rke_cluster_services.go
@@ -75,3 +75,24 @@ func expandRKEClusterServices(p []interface{}) (rancher.RKEConfigServices, error
 
 	return obj, nil
 }
+
+func expandExtraArgsArray(v []interface{}) map[string][]string {
+	extraArgMap := make(map[string][]string)
+	if v == nil || len(v) == 0 || v[0] == nil {
+		return extraArgMap
+	}
+
+	// there should only be 1 extra_args_array block per service
+	extraArgs := v[0].(map[string]interface{})["extra_arg"]
+	for _, extraArg := range extraArgs.([]interface{}) {
+		arg := extraArg.(map[string]interface{})
+		interfaceValues := arg["values"].([]interface{})
+		stringValues := make([]string, 0, len(interfaceValues))
+		for _, e := range interfaceValues {
+			stringValues = append(stringValues, e.(string))
+		}
+		extraArgMap[arg["argument"].(string)] = stringValues
+	}
+
+	return extraArgMap
+}

--- a/rke/structure_rke_cluster_services_etcd.go
+++ b/rke/structure_rke_cluster_services_etcd.go
@@ -121,6 +121,14 @@ func flattenRKEClusterServicesEtcd(in rancher.ETCDService, p []interface{}) []in
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
+	}
+
+	if len(in.WindowsExtraArgsArray) > 0 {
+		obj["win_extra_args_array"] = flattenExtraArgsArray(in.WindowsExtraArgsArray)
+	}
+
 	if len(in.ExtraBinds) > 0 {
 		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
@@ -273,6 +281,18 @@ func expandRKEClusterServicesEtcd(p []interface{}) (rancher.ETCDService, error) 
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["win_extra_args"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
+	}
+
+	if v, ok := in["win_extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rke/structure_rke_cluster_services_etcd_test.go
+++ b/rke/structure_rke_cluster_services_etcd_test.go
@@ -70,6 +70,18 @@ func init() {
 		"arg_one": "one",
 		"arg_two": "two",
 	}
+	testRKEClusterServicesETCDConf.WindowsExtraArgs = map[string]string{
+		"arg_one": "one",
+		"arg_two": "two",
+	}
+	testRKEClusterServicesETCDConf.ExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testRKEClusterServicesETCDConf.WindowsExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
 	testRKEClusterServicesETCDConf.ExtraBinds = []string{"bind_one", "bind_two"}
 	testRKEClusterServicesETCDConf.ExtraEnv = []string{"env_one", "env_two"}
 	testRKEClusterServicesETCDConf.Image = "image"
@@ -83,6 +95,38 @@ func init() {
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
+			},
+			"win_extra_args": map[string]interface{}{
+				"arg_one": "one",
+				"arg_two": "two",
+			},
+			"extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
+			},
+			"win_extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
 			},
 			"extra_binds": []interface{}{"bind_one", "bind_two"},
 			"extra_env":   []interface{}{"env_one", "env_two"},

--- a/rke/structure_rke_cluster_services_kube_api.go
+++ b/rke/structure_rke_cluster_services_kube_api.go
@@ -132,6 +132,18 @@ func flattenRKEClusterServicesKubeAPI(in rancher.KubeAPIService) ([]interface{},
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	if len(in.WindowsExtraArgs) > 0 {
+		obj["win_extra_args"] = toMapInterface(in.WindowsExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
+	}
+
+	if len(in.WindowsExtraArgsArray) > 0 {
+		obj["win_extra_args_array"] = flattenExtraArgsArray(in.WindowsExtraArgsArray)
+	}
+
 	if len(in.ExtraBinds) > 0 {
 		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
@@ -335,6 +347,18 @@ func expandRKEClusterServicesKubeAPI(p []interface{}) (rancher.KubeAPIService, e
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["win_extra_args"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
+	}
+
+	if v, ok := in["win_extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rke/structure_rke_cluster_services_kube_api_test.go
+++ b/rke/structure_rke_cluster_services_kube_api_test.go
@@ -136,6 +136,18 @@ func init() {
 		"arg_one": "one",
 		"arg_two": "two",
 	}
+	testRKEClusterServicesKubeAPIConf.WindowsExtraArgs = map[string]string{
+		"arg_one": "one",
+		"arg_two": "two",
+	}
+	testRKEClusterServicesKubeAPIConf.ExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testRKEClusterServicesKubeAPIConf.WindowsExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
 	testRKEClusterServicesKubeAPIConf.ExtraBinds = []string{"bind_one", "bind_two"}
 	testRKEClusterServicesKubeAPIConf.ExtraEnv = []string{"env_one", "env_two"}
 	testRKEClusterServicesKubeAPIConf.Image = "image"
@@ -147,6 +159,38 @@ func init() {
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
+			},
+			"win_extra_args": map[string]interface{}{
+				"arg_one": "one",
+				"arg_two": "two",
+			},
+			"extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
+			},
+			"win_extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
 			},
 			"extra_binds":               []interface{}{"bind_one", "bind_two"},
 			"extra_env":                 []interface{}{"env_one", "env_two"},

--- a/rke/structure_rke_cluster_services_kube_controller.go
+++ b/rke/structure_rke_cluster_services_kube_controller.go
@@ -17,6 +17,18 @@ func flattenRKEClusterServicesKubeController(in rancher.KubeControllerService) [
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	if len(in.WindowsExtraArgs) > 0 {
+		obj["win_extra_args"] = toMapInterface(in.WindowsExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
+	}
+
+	if len(in.WindowsExtraArgsArray) > 0 {
+		obj["win_extra_args_array"] = flattenExtraArgsArray(in.WindowsExtraArgsArray)
+	}
+
 	if len(in.ExtraBinds) > 0 {
 		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
@@ -51,6 +63,18 @@ func expandRKEClusterServicesKubeController(p []interface{}) rancher.KubeControl
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["win_extra_args"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
+	}
+
+	if v, ok := in["win_extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rke/structure_rke_cluster_services_kube_controller_test.go
+++ b/rke/structure_rke_cluster_services_kube_controller_test.go
@@ -21,6 +21,18 @@ func init() {
 		"arg_one": "one",
 		"arg_two": "two",
 	}
+	testRKEClusterServicesKubeControllerConf.WindowsExtraArgs = map[string]string{
+		"arg_one": "one",
+		"arg_two": "two",
+	}
+	testRKEClusterServicesKubeControllerConf.ExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testRKEClusterServicesKubeControllerConf.WindowsExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
 	testRKEClusterServicesKubeControllerConf.ExtraBinds = []string{"bind_one", "bind_two"}
 	testRKEClusterServicesKubeControllerConf.ExtraEnv = []string{"env_one", "env_two"}
 	testRKEClusterServicesKubeControllerConf.Image = "image"
@@ -30,6 +42,38 @@ func init() {
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
+			},
+			"win_extra_args": map[string]interface{}{
+				"arg_one": "one",
+				"arg_two": "two",
+			},
+			"extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
+			},
+			"win_extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
 			},
 			"extra_binds":              []interface{}{"bind_one", "bind_two"},
 			"extra_env":                []interface{}{"env_one", "env_two"},

--- a/rke/structure_rke_cluster_services_kubelet.go
+++ b/rke/structure_rke_cluster_services_kubelet.go
@@ -21,6 +21,18 @@ func flattenRKEClusterServicesKubelet(in rancher.KubeletService) []interface{} {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	if len(in.WindowsExtraArgs) > 0 {
+		obj["win_extra_args"] = toMapInterface(in.WindowsExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
+	}
+
+	if len(in.WindowsExtraArgsArray) > 0 {
+		obj["win_extra_args_array"] = flattenExtraArgsArray(in.WindowsExtraArgsArray)
+	}
+
 	if len(in.ExtraBinds) > 0 {
 		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
@@ -62,6 +74,18 @@ func expandRKEClusterServicesKubelet(p []interface{}) rancher.KubeletService {
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["win_extra_args"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
+	}
+
+	if v, ok := in["win_extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rke/structure_rke_cluster_services_kubelet_test.go
+++ b/rke/structure_rke_cluster_services_kubelet_test.go
@@ -24,6 +24,18 @@ func init() {
 		"arg_one": "one",
 		"arg_two": "two",
 	}
+	testRKEClusterServicesKubeletConf.WindowsExtraArgs = map[string]string{
+		"arg_one": "one",
+		"arg_two": "two",
+	}
+	testRKEClusterServicesKubeletConf.ExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testRKEClusterServicesKubeletConf.WindowsExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
 	testRKEClusterServicesKubeletConf.ExtraBinds = []string{"bind_one", "bind_two"}
 	testRKEClusterServicesKubeletConf.ExtraEnv = []string{"env_one", "env_two"}
 	testRKEClusterServicesKubeletConf.Image = "image"
@@ -34,6 +46,38 @@ func init() {
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
+			},
+			"win_extra_args": map[string]interface{}{
+				"arg_one": "one",
+				"arg_two": "two",
+			},
+			"extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
+			},
+			"win_extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
 			},
 			"extra_binds":                  []interface{}{"bind_one", "bind_two"},
 			"extra_env":                    []interface{}{"env_one", "env_two"},

--- a/rke/structure_rke_cluster_services_kubeproxy.go
+++ b/rke/structure_rke_cluster_services_kubeproxy.go
@@ -13,6 +13,18 @@ func flattenRKEClusterServicesKubeproxy(in rancher.KubeproxyService) []interface
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	if len(in.WindowsExtraArgs) > 0 {
+		obj["win_extra_args"] = toMapInterface(in.WindowsExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
+	}
+
+	if len(in.WindowsExtraArgsArray) > 0 {
+		obj["win_extra_args_array"] = flattenExtraArgsArray(in.WindowsExtraArgsArray)
+	}
+
 	if len(in.ExtraBinds) > 0 {
 		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
@@ -39,6 +51,18 @@ func expandRKEClusterServicesKubeproxy(p []interface{}) rancher.KubeproxyService
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["win_extra_args"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
+	}
+
+	if v, ok := in["win_extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rke/structure_rke_cluster_services_kubeproxy_test.go
+++ b/rke/structure_rke_cluster_services_kubeproxy_test.go
@@ -18,6 +18,18 @@ func init() {
 		"arg_one": "one",
 		"arg_two": "two",
 	}
+	testRKEClusterServicesKubeproxyConf.WindowsExtraArgs = map[string]string{
+		"arg_one": "one",
+		"arg_two": "two",
+	}
+	testRKEClusterServicesKubeproxyConf.ExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testRKEClusterServicesKubeproxyConf.WindowsExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
 	testRKEClusterServicesKubeproxyConf.ExtraBinds = []string{"bind_one", "bind_two"}
 	testRKEClusterServicesKubeproxyConf.ExtraEnv = []string{"env_one", "env_two"}
 	testRKEClusterServicesKubeproxyConf.Image = "image"
@@ -26,6 +38,38 @@ func init() {
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
+			},
+			"win_extra_args": map[string]interface{}{
+				"arg_one": "one",
+				"arg_two": "two",
+			},
+			"extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
+			},
+			"win_extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
 			},
 			"extra_binds": []interface{}{"bind_one", "bind_two"},
 			"extra_env":   []interface{}{"env_one", "env_two"},

--- a/rke/structure_rke_cluster_services_scheduler.go
+++ b/rke/structure_rke_cluster_services_scheduler.go
@@ -13,6 +13,18 @@ func flattenRKEClusterServicesScheduler(in rancher.SchedulerService) []interface
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
 
+	if len(in.WindowsExtraArgs) > 0 {
+		obj["win_extra_args"] = toMapInterface(in.WindowsExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
+	}
+
+	if len(in.WindowsExtraArgsArray) > 0 {
+		obj["win_extra_args_array"] = flattenExtraArgsArray(in.WindowsExtraArgsArray)
+	}
+
 	if len(in.ExtraBinds) > 0 {
 		obj["extra_binds"] = toArrayInterface(in.ExtraBinds)
 	}
@@ -39,6 +51,18 @@ func expandRKEClusterServicesScheduler(p []interface{}) rancher.SchedulerService
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["win_extra_args"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
+	}
+
+	if v, ok := in["win_extra_args_array"].([]interface{}); ok && len(v) > 0 {
+		obj.WindowsExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rke/structure_rke_cluster_services_scheduler_test.go
+++ b/rke/structure_rke_cluster_services_scheduler_test.go
@@ -18,6 +18,18 @@ func init() {
 		"arg_one": "one",
 		"arg_two": "two",
 	}
+	testRKEClusterServicesSchedulerConf.WindowsExtraArgs = map[string]string{
+		"arg_one": "one",
+		"arg_two": "two",
+	}
+	testRKEClusterServicesSchedulerConf.ExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testRKEClusterServicesSchedulerConf.WindowsExtraArgsArray = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
 	testRKEClusterServicesSchedulerConf.ExtraBinds = []string{"bind_one", "bind_two"}
 	testRKEClusterServicesSchedulerConf.ExtraEnv = []string{"env_one", "env_two"}
 	testRKEClusterServicesSchedulerConf.Image = "image"
@@ -26,6 +38,38 @@ func init() {
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
+			},
+			"win_extra_args": map[string]interface{}{
+				"arg_one": "one",
+				"arg_two": "two",
+			},
+			"extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
+			},
+			"win_extra_args_array": []interface{}{
+				map[string]interface{}{
+					"extra_arg": []interface{}{
+						map[string]interface{}{
+							"argument": "arg1",
+							"values":   []interface{}{"v1"},
+						},
+						map[string]interface{}{
+							"argument": "arg2",
+							"values":   []interface{}{"v2"},
+						},
+					},
+				},
 			},
 			"extra_binds": []interface{}{"bind_one", "bind_two"},
 			"extra_env":   []interface{}{"env_one", "env_two"},

--- a/rke/util.go
+++ b/rke/util.go
@@ -94,6 +94,41 @@ func toMapInterface(in map[string]string) map[string]interface{} {
 	return out
 }
 
+func flattenExtraArgsArray(in map[string][]string) []interface{} {
+
+	// ensure deterministic ordering of map
+	// to prevent flaky unit-tests. Alphabetical
+	// ordering must be honored in .tf files to ensure
+	// the planner does not detect changes when there are none.
+	// This is required as ExtraArgsArray is of type map[string][]string
+	// and there is no way to guarantee element order when flattening the map.
+	var keys []string
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+
+	var extraArgs []interface{}
+	for _, k := range keys {
+		var arr []interface{}
+		for _, e := range in[k] {
+			arr = append(arr, e)
+		}
+		extraArgs = append(extraArgs, map[string]interface{}{
+			"argument": k,
+			"values":   arr,
+		})
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"extra_arg": extraArgs,
+		},
+	}
+}
+
 func jsonToMapInterface(in string) (map[string]interface{}, error) {
 	out := make(map[string]interface{})
 	err := json.Unmarshal([]byte(in), &out)


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rke/issues/348

This PR adds the `extra_args_array`, `win_extra_args`, and `win_extra_args_array` fields to the cluster schema, along with the required flatteners, expanders, tests, and documentation. These fields (with the exception of `win_extra_args`) were added to RKE within version `1.3.12`, and as such the `go.mod` dependency has been bumped to that version. 

The `extra_args_array` field can be used in all of the services currently available (`kubeapi`, `scheduler`, `etcd`, etc), and has been accordingly added to the documentation of each of the services. However, `extra_args_array` is not a primitive field, but rather it is a custom resource with a custom schema. At the moment, I have defined the structure of that schema under each service, however I'm unsure if this follows proper terraform documentation practices. 

**WIP: Returning to this PR after some time, will update description**
