### PR TITLE
Bump rke to v1.3.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/rancher/rke v1.3.13
+	github.com/rancher/rke v1.3.15
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/sirupsen/logrus v1.8.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1029,8 +1029,8 @@ github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0 h1:ng7i8n0kzTGnXyvVK
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb h1:Tr5rialcd0u13TPRFekmCzwZNalLs5lbg6JSliUD0gY=
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb/go.mod h1:gDEwYUxOknJaOG1jjcH40PQ8U8xnvB+sHph5VirKINY=
-github.com/rancher/rke v1.3.13 h1:2dCP6rrPy8274/GP6DDRqI8DavfLQdPI7NbUghntW+A=
-github.com/rancher/rke v1.3.13/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.15 h1:I2RtkaYc11zEmy2M2mYWSaXaz7ahH+fBzePMXlG1Aww=
+github.com/rancher/rke v1.3.15/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106 h1:ed0NTDvIwulez4zVvBZ1U7mFe2PBxtHvJ9bn2l9bcZ8=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rke/issues/364

Bump terraform rke provider, RKE version: v1.3.15 which is the latest. Includes fix for https://github.com/rancher/rancher/issues/38876 which customer was asking for.

## Testing

This has been smoke tested. See results [here](https://github.com/rancher/terraform-provider-rke/issues/364#issuecomment-1292624474).