### PR TITLE
Document and add validation on enable_cri_dockerd option

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -95,7 +95,7 @@ The following arguments are supported:
 * `dind_storage_driver` - (Optional/Experimental) DinD RKE cluster storage driver (string)
 * `dind_dns_server` - (Optional/Experimental) DinD RKE cluster dns (string)
 * `dns` - (Optional) RKE k8s cluster DNS Config (list maxitems:1)
-* `enable_cri_dockerd` - (Optional) Enable/Disable CRI dockerd for kubelet. Default `false` (bool)
+* `enable_cri_dockerd` - (Optional) Enable/Disable CRI dockerd for kubelet; set it to true starting from Kubernetes version 1.24 or later. Default `false` (bool)
 * `ignore_docker_version` - (Optional) Enable/Disable RKE k8s cluster strict docker version checking. Default `false` (bool)
 * `ingress` - (Optional) RKE k8s cluster ingress controller configuration (list maxitems:1)
 * `kubernetes_version` - (Optional) K8s version to deploy. If kubernetes image is specified, image version takes precedence. Default: `rke default` (string)

--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -15,6 +15,8 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 )
 
+const latestK8sMinorThatWorksWithoutCri = "1.23."
+
 // Flatteners
 
 func flattenRKEClusterFlag(d *schema.ResourceData, in *cluster.ExternalFlags) {
@@ -528,7 +530,7 @@ func k8sVersionRequiresCri(kubernetesVersion string) bool {
 	kubernetesVersion = kubernetesVersion[1:]
 	// Go through the newer versions, stopping on 1.23.x
 	for _, v := range versions {
-		if strings.Contains(v.String(), "1.23.") {
+		if strings.Contains(v.String(), latestK8sMinorThatWorksWithoutCri) {
 			break
 		}
 		if v.String() == kubernetesVersion {

--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -3,7 +3,6 @@ package rke
 import (
 	"fmt"
 
-	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rancher/rke/cluster"
 	rancher "github.com/rancher/rke/types"
@@ -513,11 +512,11 @@ func expandRKEClusterFlag(in *schema.ResourceData, clusterFilePath string) clust
 }
 
 func k8sVersionRequiresCri(kubernetesVersion string) bool {
-
 	version, err := getClusterVersion(kubernetesVersion)
 	if err != nil {
-		// Ignoring the error, if the k8sVersion is not valid it should fail during the validation of the field.
-		log.Debug("invalid kubernetes version")
+		// This debug / error is not supposed to happen, the kubernetesVersion should be validated by the provider.
+		log.Debugf("Unable to get the semantic version for kubernetesVersion, value: %s", kubernetesVersion)
+		return false
 	}
-	return semver.MustParseRange(">= 1.24.0-rancher0")(version)
+	return parsedRangeAtLeast124(version)
 }

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func Test_k8sVersionRequiresCri(t *testing.T) {
 	type args struct {
-		kuberenetsVersion string
+		kubernetesVersion string
 	}
 	tests := []struct {
 		name string
@@ -14,266 +14,294 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 		{
 			name: "v1.26.4-rancher2-1",
 			args: args{
-				kuberenetsVersion: "v1.26.4-rancher2-1",
+				kubernetesVersion: "v1.26.4-rancher2-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.25.9-rancher2-2",
 			args: args{
-				kuberenetsVersion: "v1.25.9-rancher2-2",
-			},
-			want: true,
-		},
-		{
-			name: "v1.25.9-rancher2-1",
-			args: args{
-				kuberenetsVersion: "v1.25.9-rancher2-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.25.6-rancher4-1",
-			args: args{
-				kuberenetsVersion: "v1.25.6-rancher4-1",
+				kubernetesVersion: "v1.25.9-rancher2-2",
 			},
 			want: true,
 		},
 		{
 			name: "v1.25.6-rancher2-1",
 			args: args{
-				kuberenetsVersion: "v1.25.6-rancher2-1",
+				kubernetesVersion: "v1.25.6-rancher2-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.24.13-rancher2-2",
 			args: args{
-				kuberenetsVersion: "v1.24.13-rancher2-2",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.13-rancher2-1",
-			args: args{
-				kuberenetsVersion: "v1.24.13-rancher2-1",
+				kubernetesVersion: "v1.24.13-rancher2-2",
 			},
 			want: true,
 		},
 		{
 			name: "v1.24.10-rancher4-1",
 			args: args{
-				kuberenetsVersion: "v1.24.10-rancher4-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.10-rancher2-1",
-			args: args{
-				kuberenetsVersion: "v1.24.10-rancher2-1",
+				kubernetesVersion: "v1.24.10-rancher4-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.24.9-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.24.9-rancher1-1",
+				kubernetesVersion: "v1.24.9-rancher1-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.24.8-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.24.8-rancher1-1",
+				kubernetesVersion: "v1.24.8-rancher1-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.24.6-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.24.6-rancher1-1",
+				kubernetesVersion: "v1.24.6-rancher1-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.24.4-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.24.4-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.2-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.24.2-rancher1-1",
+				kubernetesVersion: "v1.24.4-rancher1-1",
 			},
 			want: true,
 		},
 		{
 			name: "v1.23.16-rancher2-3",
 			args: args{
-				kuberenetsVersion: "v1.23.16-rancher2-3",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.16-rancher2-1",
-			args: args{
-				kuberenetsVersion: "v1.23.16-rancher2-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.15-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.15-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.14-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.14-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.12-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.12-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.10-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.10-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.8-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.8-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.7-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.7-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.6-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.6-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.4-rancher1-2",
-			args: args{
-				kuberenetsVersion: "v1.23.4-rancher1-2",
-			},
-			want: true,
-		},
-		{
-			name: "v1.23.4-rancher1-1",
-			args: args{
-				kuberenetsVersion: "v1.23.4-rancher1-2",
-			},
-			want: true,
-		},
-		{
-			name: "v1.22.17-rancher1-2",
-			args: args{
-				kuberenetsVersion: "v1.22.17-rancher1-2",
+				kubernetesVersion: "v1.23.16-rancher2-3",
 			},
 			want: false,
 		},
 		{
-			name: "v1.22.17-rancher1-1",
+			name: "v1.23.15-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.17-rancher1-1",
+				kubernetesVersion: "v1.23.15-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.14-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.23.14-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.12-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.23.12-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.10-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.23.10-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.8-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.23.8-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.7-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.23.7-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.6-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.23.6-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.23.4-rancher1-2",
+			args: args{
+				kubernetesVersion: "v1.23.4-rancher1-2",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.17-rancher1-2",
+			args: args{
+				kubernetesVersion: "v1.22.17-rancher1-2",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.16-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.16-rancher1-1",
+				kubernetesVersion: "v1.22.16-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.15-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.15-rancher1-1",
+				kubernetesVersion: "v1.22.15-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.13-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.13-rancher1-1",
+				kubernetesVersion: "v1.22.13-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.11-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.11-rancher1-1",
+				kubernetesVersion: "v1.22.11-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.10-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.10-rancher1-1",
+				kubernetesVersion: "v1.22.10-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.9-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.9-rancher1-1",
+				kubernetesVersion: "v1.22.9-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.7-rancher1-2",
 			args: args{
-				kuberenetsVersion: "v1.22.7-rancher1-2",
+				kubernetesVersion: "v1.22.7-rancher1-2",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.7-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.7-rancher1-1",
+				kubernetesVersion: "v1.22.7-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.6-rancher1-1",
 			args: args{
-				kuberenetsVersion: "v1.22.6-rancher1-1",
+				kubernetesVersion: "v1.22.6-rancher1-1",
 			},
 			want: false,
 		},
 		{
 			name: "v1.22.5-rancher2-1",
 			args: args{
-				kuberenetsVersion: "v1.22.5-rancher2-1",
+				kubernetesVersion: "v1.22.5-rancher2-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.4-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.22.4-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.14-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.14-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.13-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.13-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.12-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.12-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.10-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.10-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.9-rancher1-2",
+			args: args{
+				kubernetesVersion: "v1.21.9-rancher1-2",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.8-rancher2-1",
+			args: args{
+				kubernetesVersion: "v1.21.8-rancher2-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.7-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.7-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.6-rancher1-2",
+			args: args{
+				kubernetesVersion: "v1.21.6-rancher1-2",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.5-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.5-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.21.4-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.21.4-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.20.15-rancher2-2",
+			args: args{
+				kubernetesVersion: "v1.20.15-rancher2-2",
 			},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := k8sVersionRequiresCri(tt.args.kuberenetsVersion); got != tt.want {
+			if got := k8sVersionRequiresCri(tt.args.kubernetesVersion); got != tt.want {
 				t.Errorf("k8sVersionRequiresCri() = %v, want %v", got, tt.want)
 			}
 		})

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -1,0 +1,281 @@
+package rke
+
+import "testing"
+
+func Test_k8sVersionRequiresCri(t *testing.T) {
+	type args struct {
+		kuberenetsVersion string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "v1.26.4-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.26.4-rancher2-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.25.9-rancher2-2",
+			args: args{
+				kuberenetsVersion: "v1.25.9-rancher2-2",
+			},
+			want: true,
+		},
+		{
+			name: "v1.25.9-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.25.9-rancher2-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.25.6-rancher4-1",
+			args: args{
+				kuberenetsVersion: "v1.25.6-rancher4-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.25.6-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.25.6-rancher2-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.13-rancher2-2",
+			args: args{
+				kuberenetsVersion: "v1.24.13-rancher2-2",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.13-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.24.13-rancher2-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.10-rancher4-1",
+			args: args{
+				kuberenetsVersion: "v1.24.10-rancher4-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.10-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.24.10-rancher2-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.9-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.24.9-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.8-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.24.8-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.6-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.24.6-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.4-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.24.4-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.24.2-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.24.2-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.16-rancher2-3",
+			args: args{
+				kuberenetsVersion: "v1.23.16-rancher2-3",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.16-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.23.16-rancher2-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.15-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.15-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.14-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.14-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.12-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.12-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.10-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.10-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.8-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.8-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.7-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.7-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.6-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.6-rancher1-1",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.4-rancher1-2",
+			args: args{
+				kuberenetsVersion: "v1.23.4-rancher1-2",
+			},
+			want: true,
+		},
+		{
+			name: "v1.23.4-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.23.4-rancher1-2",
+			},
+			want: true,
+		},
+		{
+			name: "v1.22.17-rancher1-2",
+			args: args{
+				kuberenetsVersion: "v1.22.17-rancher1-2",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.17-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.17-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.16-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.16-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.15-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.15-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.13-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.13-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.11-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.11-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.10-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.10-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.9-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.9-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.7-rancher1-2",
+			args: args{
+				kuberenetsVersion: "v1.22.7-rancher1-2",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.7-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.7-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.6-rancher1-1",
+			args: args{
+				kuberenetsVersion: "v1.22.6-rancher1-1",
+			},
+			want: false,
+		},
+		{
+			name: "v1.22.5-rancher2-1",
+			args: args{
+				kuberenetsVersion: "v1.22.5-rancher2-1",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := k8sVersionRequiresCri(tt.args.kuberenetsVersion); got != tt.want {
+				t.Errorf("k8sVersionRequiresCri() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -26,51 +26,9 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "v1.25.6-rancher2-1",
-			args: args{
-				kubernetesVersion: "v1.25.6-rancher2-1",
-			},
-			want: true,
-		},
-		{
 			name: "v1.24.13-rancher2-2",
 			args: args{
 				kubernetesVersion: "v1.24.13-rancher2-2",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.10-rancher4-1",
-			args: args{
-				kubernetesVersion: "v1.24.10-rancher4-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.9-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.24.9-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.8-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.24.8-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.6-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.24.6-rancher1-1",
-			},
-			want: true,
-		},
-		{
-			name: "v1.24.4-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.24.4-rancher1-1",
 			},
 			want: true,
 		},
@@ -82,62 +40,6 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "v1.23.15-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.15-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.14-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.14-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.12-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.12-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.10-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.10-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.8-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.8-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.7-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.7-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.6-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.23.6-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.23.4-rancher1-2",
-			args: args{
-				kubernetesVersion: "v1.23.4-rancher1-2",
-			},
-			want: false,
-		},
-		{
 			name: "v1.22.17-rancher1-2",
 			args: args{
 				kubernetesVersion: "v1.22.17-rancher1-2",
@@ -145,149 +47,9 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "v1.22.16-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.16-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.15-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.15-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.13-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.13-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.11-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.11-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.10-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.10-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.9-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.9-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.7-rancher1-2",
-			args: args{
-				kubernetesVersion: "v1.22.7-rancher1-2",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.7-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.7-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.6-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.6-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.5-rancher2-1",
-			args: args{
-				kubernetesVersion: "v1.22.5-rancher2-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.22.4-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.22.4-rancher1-1",
-			},
-			want: false,
-		},
-		{
 			name: "v1.21.14-rancher1-1",
 			args: args{
 				kubernetesVersion: "v1.21.14-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.13-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.21.13-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.12-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.21.12-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.10-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.21.10-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.9-rancher1-2",
-			args: args{
-				kubernetesVersion: "v1.21.9-rancher1-2",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.8-rancher2-1",
-			args: args{
-				kubernetesVersion: "v1.21.8-rancher2-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.7-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.21.7-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.6-rancher1-2",
-			args: args{
-				kubernetesVersion: "v1.21.6-rancher1-2",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.5-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.21.5-rancher1-1",
-			},
-			want: false,
-		},
-		{
-			name: "v1.21.4-rancher1-1",
-			args: args{
-				kubernetesVersion: "v1.21.4-rancher1-1",
 			},
 			want: false,
 		},

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -60,6 +60,13 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "invalid",
+			args: args{
+				kubernetesVersion: "invalid",
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/rke/util.go
+++ b/rke/util.go
@@ -19,6 +19,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var parsedRangeAtLeast124 = semver.MustParseRange(">= 1.24.0-rancher0")
+
 func splitImportID(s string) ([]string, error) {
 	sep := ":"
 	if len(s) == 0 {

--- a/rke/util.go
+++ b/rke/util.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver"
 	ghodssyaml "github.com/ghodss/yaml"
 	gover "github.com/hashicorp/go-version"
 	uuid "github.com/satori/go.uuid"
@@ -250,6 +251,18 @@ func sortVersions(list map[string]string) ([]*gover.Version, error) {
 
 	sort.Sort(gover.Collection(versions))
 	return versions, nil
+}
+
+func getClusterVersion(version string) (semver.Version, error) {
+	var parsedVersion semver.Version
+	if len(version) <= 1 || !strings.HasPrefix(version, "v") {
+		return parsedVersion, fmt.Errorf("%s is not valid version", version)
+	}
+	parsedVersion, err := semver.Parse(version[1:])
+	if err != nil {
+		return parsedVersion, fmt.Errorf("%s is not valid semver", version)
+	}
+	return parsedVersion, nil
 }
 
 func getLatestVersion(list map[string]string) (string, error) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #404 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
K8s 1.24+ needs enable_cri_dockerd to be set to true for clusters to successfully provision.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->


We cant do that change.

 a) change the default value of enable_cri_dockerd to true

    This would change the behavior of cluster using k8s 1.23 or less.

b) Set enable_cri_dockerd to true during execution time:

    This would generate inconsistency on terraform plans and would result on the resource being applied every single time.


Add to the docs that the user need to change the value of the field.  

Also added a validation function on the Expander that is used to create/update the cluster. 

This can't be a "ValidationFunc" from terraform as it depends on 2 fields.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Added a validation for the function that checks the k8s version 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. Remove inapplicable bullet points -->
* Test types added/modified:

    * None
* If "None" - Reason:
  Change to the docs. 
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->


Summary: 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
There is no regression, this is a doc only


