### PR TITLE
Use dl.k8s.io for getting kubectl

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -6,7 +6,7 @@ RUN  apt-get update && \
      apt-get clean && \
      rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* && \
      go get -u golang.org/x/lint/golint && \
-     curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/bin/kubectl && chmod 755 /usr/bin/kubectl && \
+     curl -L https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/bin/kubectl && chmod 755 /usr/bin/kubectl && \
      curl -LO https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_linux_amd64.zip && unzip terraform_0.12.20_linux_amd64.zip && \
      mv terraform /usr/bin/terraform && chmod 755 /usr/bin/terraform && rm terraform_0.12.20_linux_amd64.zip 
 VOLUME /go/src/github.com/rancher/terraform-provider-rke


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rke/issues/421

## Problem
Preparing for GCS bucket deprecation at some point (https://github.com/kubernetes/k8s.io/issues/2396)

## Solution
Change to the currently documented source

Replaces https://github.com/rancher/terraform-provider-rke/pull/419

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. Remove inapplicable bullet points -->
* Test types added/modified:
    * Unit
    * None
* If "None" - Reason:
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_

### Terraform

<details>
<summary>Click to Expand Terraform</summary>

<!-- Paste terraform here, link terraform repo, or upload terraform as attachment. Make sure to sanitize sensitive data -->

</details>
