### PR TITLE
Fix import cluster issue with forced flag:

### DIFF
--- a/rke/structure_rke_cluster.go
+++ b/rke/structure_rke_cluster.go
@@ -293,11 +293,11 @@ func expandRKECluster(in *schema.ResourceData) (string, *rancher.RancherKubernet
 		obj.DNS = expandRKEClusterDNS(v)
 	}
 
-	if v, ok := in.Get("enable_cri_dockerd").(bool); ok {
+	if v, ok := in.Get("enable_cri_dockerd").(bool); ok && obj.EnableCRIDockerd == nil {
 		obj.EnableCRIDockerd = &v
 	}
 
-	if v, ok := in.Get("ignore_docker_version").(bool); ok {
+	if v, ok := in.Get("ignore_docker_version").(bool); ok && obj.IgnoreDockerVersion == nil {
 		obj.IgnoreDockerVersion = &v
 	}
 

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -11,13 +11,13 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 		args args
 		want bool
 	}{
-        {
-            name: "v1.26.9-rancher1-1",
-            args: args{
-                kubernetesVersion: "v1.26.9-rancher1-1",
-            },
-            want: true,
-        },
+	        {
+	            name: "v1.26.9-rancher1-1",
+	            args: args{
+	                kubernetesVersion: "v1.26.9-rancher1-1",
+	            },
+	            want: true,
+	        },
 		{
 			name: "v1.26.4-rancher2-1",
 			args: args{

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -11,13 +11,13 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 		args args
 		want bool
 	}{
-	        {
+		{
 			name: "v1.26.9-rancher1-1",
 			args: args{
 				kubernetesVersion: "v1.26.9-rancher1-1",
 			},
 			want: true,
-	        },
+		},
 		{
 			name: "v1.26.4-rancher2-1",
 			args: args{

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -12,11 +12,11 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 		want bool
 	}{
 	        {
-	            name: "v1.26.9-rancher1-1",
-	            args: args{
-	                kubernetesVersion: "v1.26.9-rancher1-1",
-	            },
-	            want: true,
+			name: "v1.26.9-rancher1-1",
+			args: args{
+				kubernetesVersion: "v1.26.9-rancher1-1",
+			},
+			want: true,
 	        },
 		{
 			name: "v1.26.4-rancher2-1",

--- a/rke/structure_rke_cluster_test.go
+++ b/rke/structure_rke_cluster_test.go
@@ -11,6 +11,13 @@ func Test_k8sVersionRequiresCri(t *testing.T) {
 		args args
 		want bool
 	}{
+        {
+            name: "v1.26.9-rancher1-1",
+            args: args{
+                kubernetesVersion: "v1.26.9-rancher1-1",
+            },
+            want: true,
+        },
 		{
 			name: "v1.26.4-rancher2-1",
 			args: args{


### PR DESCRIPTION
Issue: #432

enable_cri_dockerd =  true


## Issue: https://github.com/rancher/terraform-provider-rke/issues/432

## Problem
Issue when importing a cluster. Fails with message:
`kubernetes version ..... requires enable_cri_dockerd to be set to true`
enable_cri_dockerd  flas always set to the default value `false`
## Solution
Use the value set at the cluster.yaml file.
Use default only if not set at the cluster.yaml file

## Testing
Tested importing a cluster and setting the value to true

## Engineering Testing
### Manual Testing
Tested importing a cluster and setting the value to true

### Automated Testing
Added latest K8s version at the automated test.