### PR TITLE
[1.5] bump RKE to 1.5.13, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 Terraform Provider for RKE
 ==================================
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/rancher/terraform-provider-rke)](https://goreportcard.com/report/github.com/rancher/terraform-provider-rke) [![Build Status](https://drone-publish.rancher.io/api/badges/rancher/terraform-provider-rke/status.svg)](https://drone-publish.rancher.io/rancher/terraform-provider-rke)
+[![Go Report Card](https://goreportcard.com/badge/github.com/rancher/terraform-provider-rke)](https://goreportcard.com/report/github.com/rancher/terraform-provider-rke)
 
 Terraform RKE providers can easily deploy Kubernetes clusters with [Rancher Kubernetes Engine](https://github.com/rancher/rke).  
 
 - Website: https://registry.terraform.io/providers/rancher/rke
 - Docs: https://registry.terraform.io/providers/rancher/rke/latest/docs
-- [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
-- Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 
@@ -16,7 +14,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.12.x
-- [Go](https://golang.org/doc/install) 1.14 to build the provider plugin
+- [Go](https://golang.org/doc/install) 1.20 to build the provider plugin
 - [Docker](https://docs.docker.com/install/) 17.03.x to run acceptance tests
 
 Installing The Provider
@@ -34,15 +32,15 @@ How to install manually:
 * Place provider binary on your terraform plugin directory: `mv terraform-provider-rke_vX.Y.Z <TERRAFORM_PLUGIN_DIRECTORY>`
   * `terraform init` will search the following terraform plugin directories (More info at [terra-farm.github.io](https://terra-farm.github.io/main/installation.html)):
 
-| Directory | Purpose |
-|-|-|
-| . | In case the provider is only used in a single Terraform project. |
-| Location of the terraform binary (/usr/local/bin, for example.) | For airgapped installations; see terraform bundle. |
-| terraform.d/plugins/<OS>_<ARCH> | For checking custom providers into a configuration’s VCS repository. Not usually desirable, but sometimes necessary in Terraform Enterprise. |
-| .terraform/plugins/<OS>_<ARCH> | Automatically downloaded providers. |
-| ~/.terraform.d/plugins | The user plugins directory. |
-| ~/.terraform.d/plugins/<OS>_<ARCH> | The user plugins directory, with explicit OS and architecture. |
-| /my/custom/path | Custom plugin directory. Use the `-plug-dir=/my/custom/path` when running `terraform init` |
+| Directory                                                       | Purpose                                                                                                                                      |
+|-----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| .                                                               | In case the provider is only used in a single Terraform project.                                                                             |
+| Location of the terraform binary (/usr/local/bin, for example.) | For airgapped installations; see terraform bundle.                                                                                           |
+| terraform.d/plugins/<OS>_<ARCH>                                 | For checking custom providers into a configuration’s VCS repository. Not usually desirable, but sometimes necessary in Terraform Enterprise. |
+| .terraform/plugins/<OS>_<ARCH>                                  | Automatically downloaded providers.                                                                                                          |
+| ~/.terraform.d/plugins                                          | The user plugins directory.                                                                                                                  |
+| ~/.terraform.d/plugins/<OS>_<ARCH>                              | The user plugins directory, with explicit OS and architecture.                                                                               |
+| /my/custom/path                                                 | Custom plugin directory. Use the `-plug-dir=/my/custom/path` when running `terraform init`                                                   |
 
 Building The Provider
 ---------------------
@@ -64,7 +62,7 @@ $ cd $GOPATH/src/github.com/rancher/terraform-provider-rke
 $ make build
 ```
 
-**Current master is focusing on RKE v1.0.x** There are some breaking changes from previous provider version.
+**Current master is focusing on RKE v1.x** There are some breaking changes from previous provider version.
 
 **If you use RKE v0.2.x or v0.1.x, please set proper branch.**
 
@@ -129,7 +127,8 @@ Branching the Provider
 
 The provider is branched to align with RKE versions:
 
-- `master` is aligned with RKE v1.5
+- `master` is aligned with RKE v1.6
+- `release/v1.5` is aligned with RKE v1.5
 - `release/v1.4` is aligned with RKE v1.4
 - `release/v1.3` is aligned with RKE v1.3 
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
-	github.com/rancher/rke v1.5.7
+	github.com/rancher/rke v1.5.13
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1512,8 +1512,8 @@ github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa h1:eRhvQJjIpPxJunlS3
 github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa/go.mod h1:utdskbIL7kdVvPCUFPEJQDWJwPHGFpUCRfVkX2G2Xxg=
 github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c h1:ayqZqJ4AYYVaZGlBztLBij81z/QRsSFbQfxs9bzA+Tg=
 github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c/go.mod h1:WbNpu/HwChwKk54W0rWBdioxYVVZwVVz//UX84m/NvY=
-github.com/rancher/rke v1.5.7 h1:pCVziDwgulQc2WgRkisY6sEo3DFGgu1StE66UbkuF2c=
-github.com/rancher/rke v1.5.7/go.mod h1:vojhOf8U8VCmw7y17OENWXSIfEFPEbXCMQcmI7xN7i8=
+github.com/rancher/rke v1.5.13 h1:Y7e3qI0G2HbU3Vm5k3Sqeq+UR2w114K5yY6wT9VFKcY=
+github.com/rancher/rke v1.5.13/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
 github.com/rancher/wrangler/v2 v2.1.3 h1:ggCPFD14emodJjR4Pi6mcDGgtNo04tjCKZ71S76uWg8=
 github.com/rancher/wrangler/v2 v2.1.3/go.mod h1:af5OaGU/COgreQh1mRbKiUI64draT2NN34uk+PALFY8=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=


### PR DESCRIPTION
https://github.com/rancher/terraform-provider-rke/issues/459

This PR bumps RKE to 1.5.13, and updates README

**Testing**

Since there is no CI available to run tests on the PR, all tests are executed locally using `make test`.

The basic functionality has also been verified.

Below is the Terraform configuration file used to create a one-node RKE cluster with all roles. Note that Terraform is configured to use the binary built from the PR:

```
# main.tf

terraform {
  required_providers {
    rke = {
      source = "rancher/rke"
      version = "1.4.4"
    }
  }
}

# Configure the RKE provider
provider "rke" {
  debug = true
  log_file = "./logfile.txt"
}
resource rke_cluster "cluster" {
  enable_cri_dockerd = "true"
  kubernetes_version = "v1.25.16-rancher2-3"
  nodes {
    address = "x.xx.x.x"
    internal_address = "x.xx.x.x"
    user    = "root"
    role    = ["controlplane", "etcd", "worker"]
  }


resource "local_file" "kube_cluster_yaml" {
  filename = "${path.root}/kube_config_cluster.yml"
  content  = rke_cluster.cluster.kube_config_yaml
}

```
 

