### PR TITLE
[1.6] fix env var in the GHA

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,11 +37,11 @@ jobs:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
-          echo -n "${{ env.GPG_KEY }}" | base64 --decode | gpg --import --batch >/dev/null          
+          echo -n "$GPG_KEY" | base64 --decode | gpg --import --batch >/dev/null          
           echo "signing SHASUM file"
           VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
           SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rke_"$VERSION_NO_V"_SHA256SUMS
-          echo ${{ env.GPG_PASSPHRASE }} | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "$SHASUM_FILE".sig --sign "$SHASUM_FILE"
+          echo "$GPG_PASSPHRASE" | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "$SHASUM_FILE".sig --sign "$SHASUM_FILE"
 
       - name: GH release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,11 +37,11 @@ jobs:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
-          echo -n "${{ env.GPG_KEY }}" | base64 --decode | gpg --import --batch >/dev/null          
+          echo -n "$GPG_KEY" | base64 --decode | gpg --import --batch >/dev/null          
           echo "signing SHASUM file"
           VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
           SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rke_"$VERSION_NO_V"_SHA256SUMS
-          echo ${{ env.GPG_PASSPHRASE }} | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "$SHASUM_FILE".sig --sign "$SHASUM_FILE"
+          echo "$GPG_PASSPHRASE" | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "$SHASUM_FILE".sig --sign "$SHASUM_FILE"
 
       - name: GH release
         env:


### PR DESCRIPTION
This PR fixes the issue where the env var is not properly substituted in the CI. 

failure in CI: https://github.com/rancher/terraform-provider-rke/actions/runs/11352817560/job/31576422159#step:6:27

GHA docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#example-usage-of-the-vars-context