### PR TITLE
[1.6] set the trust level non-interactively

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -41,8 +41,8 @@ jobs:
           # Extract the key ID from the list of secret keys
           GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5}')
           echo "Extracted GPG Key ID: $GPG_KEY_ID"
-          # Automatically trust the key
-          echo -e "5\ny\n" | gpg --command-fd 0 --expert --edit-key "$GPG_KEY_ID" trust quit
+          # Automatically trust the key by creating a trust level entry for the key (ultimate trust)
+          echo -e "$GPG_KEY_ID:6:" | gpg --import-ownertrust
           echo "signing SHASUM file"
           VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
           SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rke_"$VERSION_NO_V"_SHA256SUMS

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,8 +41,8 @@ jobs:
           # Extract the key ID from the list of secret keys
           GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5}')
           echo "Extracted GPG Key ID: $GPG_KEY_ID"
-          # Automatically trust the key
-          echo -e "5\ny\n" | gpg --command-fd 0 --expert --edit-key "$GPG_KEY_ID" trust quit
+          # Automatically trust the key by creating a trust level entry for the key (ultimate trust)
+          echo -e "$GPG_KEY_ID:6:" | gpg --import-ownertrust
           echo "signing SHASUM file"
           VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
           SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rke_"$VERSION_NO_V"_SHA256SUMS


### PR DESCRIPTION
We need to set the trust level non-interactively because GitHub Actions runs in a non-interactive environment 

error:
```
gpg: cannot open '/dev/tty': No such device or address
```

https://github.com/rancher/terraform-provider-rke/actions/runs/11354606111/job/31582211790#step:6:34